### PR TITLE
Fixes for deprecated behavior and improvements for iterative building of dataframe

### DIFF
--- a/coastline_loader/gshhs.py
+++ b/coastline_loader/gshhs.py
@@ -83,6 +83,7 @@ class GetCoastline:
             pd.DataFrame: costlines polygons
         """
         df = pd.DataFrame([])
+        dataframes = []
         for index, (feature, area) in enumerate(zip(self.gdf.geometry, self.gdf.area)):
             lon, lat = feature.exterior.coords.xy
             poly_id = [index] * len(feature.exterior.coords)
@@ -90,6 +91,6 @@ class GetCoastline:
             tmp = pd.DataFrame(
                 {"polygon_id": poly_id, "longitude": lon, "latitude": lat, "area": area}
             )
-            df = df.append(tmp)
-
+            dataframes.append(tmp)
+        df = pd.concat(dataframes, ignore_index=True)
         return df.reset_index(drop=True)


### PR DESCRIPTION
Previously, the code relied on using `dataframe.append()` repeatedly, which has been deprecated.

My update builds up the polygon dataframe into a list, then at the end, turns the list into a dataframe through one `.concat`, which is apparently the recommended behavior:

https://stackoverflow.com/questions/75956209/error-dataframe-object-has-no-attribute-append
